### PR TITLE
Until we have a better solution we disable it

### DIFF
--- a/generators/arduino.js
+++ b/generators/arduino.js
@@ -76,7 +76,7 @@ Blockly.Arduino.PinTypes = {
   SPI: 'SPI'
 };
 
-Blockly.Arduino.CodeVariablesPrefix = 'oc_';
+Blockly.Arduino.CodeVariablesPrefix = '';
 
 /**
  * Arduino generator short name for


### PR DESCRIPTION
We just disable it, as we have custom blocks which do not conform the blockly-pattern. Those blocks are broken with the prefixing of variables.